### PR TITLE
fix: agregar llave faltante en objeto de ruta /recepcionista/editar-cita

### DIFF
--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -133,10 +133,11 @@ const router = createRouter({
       path: '/admin/salas',
       component: SalasManagement
     },
-      path: '/recepcionista/editar-cita/:id', // IMPORTANTE: :id
+    {
+      path: '/recepcionista/editar-cita/:id',
       name: 'EditarCita',
       component: () => import('../views/recepcionista/EditarCita.vue'),
-      meta: { requiresAuth: true, role: 'RECEPCIONISTA' } // O tus guards
+      meta: { requiresAuth: true, role: 'RECEPCIONISTA' }
     },
 
     {


### PR DESCRIPTION
- Corregido error de sintaxis JavaScript en router/index.js línea 136
- Faltaba la llave de apertura { para el objeto de ruta
- El error causaba que Vite no pudiera parsear el archivo
- Build verificado y funcional